### PR TITLE
fix token burn logic

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "workbench.colorCustomizations": {
+        "activityBar.background": "#062C61",
+        "titleBar.activeBackground": "#093D88",
+        "titleBar.activeForeground": "#F7FAFE"
+    }
+}

--- a/sources/jetton.tact
+++ b/sources/jetton.tact
@@ -1,88 +1,92 @@
 import "@stdlib/ownable";
 import "./messages";
-
 // ============================================================================================================ //
 @interface("org.ton.jetton.master")
 trait Jetton with Ownable {
-
-    total_supply: Int; 
+    total_supply: Int;
     mintable: Bool;
     owner: Address;
     content: Cell;
-    
-    receive(msg: TokenUpdateContent) {
-        self.requireOwner();                // Allow changing content only by owner
-        self.content = msg.content;         // Update content
+
+    receive(msg: TokenUpdateContent){
+        self.requireOwner(); // Allow changing content only by owner
+        self.content = msg.content; // Update content
     }
 
-    receive(msg: TokenBurnNotification) {
-        self.requireSenderAsWalletOwner(msg.response_destination!!);       // Check wallet
-        self.total_supply = self.total_supply - msg.amount; // Update supply
-        if (msg.response_destination != null) { // Cashback
+    receive(msg: TokenBurnNotification){
+        self.requireSenderAsWalletOwner(msg.sender); // Check wallet
+        self.total_supply = (self.total_supply - msg.amount); // Update supply
+        if (msg.response_destination != null) {
+            // Cashback
             send(SendParameters{
-                to: msg.response_destination!!, 
-                value: 0,
-                bounce: false,
-                mode: SendRemainingValue,
-                body: TokenExcesses{ query_id: msg.query_id }.toCell()
-            });
+                    to: msg.response_destination!!,
+                    value: 0,
+                    bounce: false,
+                    mode: SendRemainingValue,
+                    body: TokenExcesses{query_id: msg.query_id}.toCell()
+                }
+            );
         }
     }
 
     // https://github.com/ton-blockchain/TEPs/blob/master/text/0089-jetton-wallet-discovery.md
-    receive(msg: ProvideWalletAddress) { // 0x2c76b973
+    receive(msg: ProvideWalletAddress){
+        // 0x2c76b973
         require(context().value >= ton("0.0061"), "Insufficient gas");
         let init: StateInit = initOf JettonDefaultWallet(msg.owner_address, myAddress());
         if (msg.include_address) {
             send(SendParameters{
-                to: sender(),
-                value: 0,
-                mode: SendRemainingValue,
-                body: TakeWalletAddress{
-                    query_id: msg.query_id,
-                    wallet_address: contractAddress(init),
-                    owner_address: beginCell().storeBool(true).storeAddress(msg.owner_address).endCell().asSlice()
-                }.toCell()
-            });
+                    to: sender(),
+                    value: 0,
+                    mode: SendRemainingValue,
+                    body: TakeWalletAddress{
+                        query_id: msg.query_id,
+                        wallet_address: contractAddress(init),
+                        owner_address: beginCell().storeBool(true).storeAddress(msg.owner_address).endCell().asSlice()
+                    }.toCell()
+                }
+            );
         } else {
             send(SendParameters{
-                to: sender(),
-                value: 0,
-                mode: SendRemainingValue,
-                body: TakeWalletAddress { // 0xd1735400
-                    query_id: msg.query_id,
-                    wallet_address: contractAddress(init),
-                    owner_address: beginCell().storeBool(false).endCell().asSlice()
-                }.toCell()
-            });
+                    to: sender(),
+                    value: 0,
+                    mode: SendRemainingValue,
+                    body: TakeWalletAddress{ // 0xd1735400
+                        query_id: msg.query_id,
+                        wallet_address: contractAddress(init),
+                        owner_address: beginCell().storeBool(false).endCell().asSlice()
+                    }.toCell()
+                }
+            );
         }
     }
 
-    // Private Methods // 
+    // Private Methods //
     // @to The Address receive the Jetton token after minting
     // @amount The amount of Jetton token being minted
     // @response_destination The previous owner address
     fun mint(to: Address, amount: Int, response_destination: Address) {
         require(self.mintable, "Can't Mint Anymore");
-        self.total_supply = self.total_supply + amount; // Update total supply
+        self.total_supply = (self.total_supply + amount); // Update total supply
 
         let winit: StateInit = self.getJettonWalletInit(to); // Create message
         send(SendParameters{
-            to: contractAddress(winit), 
-            value: 0, 
-            bounce: true,
-            mode: SendRemainingValue,
-            body: TokenTransferInternal{ 
-                query_id: 0,
-                amount: amount,
-                from: myAddress(),
-                response_destination: response_destination,
-                forward_ton_amount: 0,
-                forward_payload: beginCell().endCell().asSlice()
-            }.toCell(),
-            code: winit.code,
-            data: winit.data
-        });
+                to: contractAddress(winit),
+                value: 0,
+                bounce: true,
+                mode: SendRemainingValue,
+                body: TokenTransferInternal{
+                    query_id: 0,
+                    amount: amount,
+                    from: myAddress(),
+                    response_destination: response_destination,
+                    forward_ton_amount: 0,
+                    forward_payload: beginCell().endCell().asSlice()
+                }.toCell(),
+                code: winit.code,
+                data: winit.data
+            }
+        );
     }
 
     fun requireSenderAsWalletOwner(owner: Address) {
@@ -96,14 +100,16 @@ trait Jetton with Ownable {
     }
 
     // ====== Get Methods ====== //
+
     get fun get_jetton_data(): JettonData {
-        return JettonData{ 
-            total_supply: self.total_supply, 
-            mintable: self.mintable, 
-            owner: self.owner, 
-            content: self.content, 
-            wallet_code: initOf JettonDefaultWallet(self.owner, myAddress()).code
-        };
+        return
+            JettonData{
+                total_supply: self.total_supply,
+                mintable: self.mintable,
+                owner: self.owner,
+                content: self.content,
+                wallet_code: initOf JettonDefaultWallet(self.owner, myAddress()).code
+            };
     }
 
     get fun get_wallet_address(owner: Address): Address {
@@ -113,144 +119,139 @@ trait Jetton with Ownable {
 
 // ============================================================ //
 @interface("org.ton.jetton.wallet")
-contract JettonDefaultWallet {
+contract JettonDefaultWallet
+{
     const minTonsForStorage: Int = ton("0.019");
     const gasConsumption: Int = ton("0.013");
-
     balance: Int as coins = 0;
     owner: Address;
     master: Address;
-
-    init(owner: Address, master: Address) {
+    init(owner: Address, master: Address){
         self.balance = 0;
         self.owner = owner;
         self.master = master;
     }
 
-    receive(msg: TokenTransfer) { // 0xf8a7ea5
+    receive(msg: TokenTransfer){
+        // 0xf8a7ea5
         let ctx: Context = context(); // Check sender
         require(ctx.sender == self.owner, "Invalid sender");
-
-        let final: Int = ctx.readForwardFee() * 2 + 
-                            2 * self.gasConsumption + 
-                                self.minTonsForStorage + 
-                                    msg.forward_ton_amount;   // Gas checks, forward_ton = 0.152
-        require(ctx.value > final, "Invalid value"); 
-
+        let final: Int =
+            (((ctx.readForwardFee() * 2 + 2 * self.gasConsumption) + self.minTonsForStorage) + msg.forward_ton_amount); // Gas checks, forward_ton = 0.152
+        require(ctx.value > final, "Invalid value");
         // Update balance
-        self.balance = self.balance - msg.amount; 
+        self.balance = (self.balance - msg.amount);
         require(self.balance >= 0, "Invalid balance");
-
-        let init: StateInit = initOf JettonDefaultWallet(msg.sender, self.master);  
+        let init: StateInit = initOf JettonDefaultWallet(msg.sender, self.master);
         let wallet_address: Address = contractAddress(init);
         send(SendParameters{
-            to: wallet_address, 
-            value: 0,
-            mode: SendRemainingValue, 
-            bounce: false,
-            body: TokenTransferInternal{ // 0x178d4519
-                query_id: msg.query_id,
-                amount: msg.amount,
-                from: self.owner,
-                response_destination: msg.response_destination,
-                forward_ton_amount: msg.forward_ton_amount,
-                forward_payload:  msg.forward_payload
-            }.toCell(),
-            code: init.code,
-            data: init.data
-        });
+                to: wallet_address,
+                value: 0,
+                mode: SendRemainingValue,
+                bounce: true,
+                body: TokenTransferInternal{ // 0x178d4519
+                    query_id: msg.query_id,
+                    amount: msg.amount,
+                    from: self.owner,
+                    response_destination: msg.response_destination,
+                    forward_ton_amount: msg.forward_ton_amount,
+                    forward_payload: msg.forward_payload
+                }.toCell(),
+                code: init.code,
+                data: init.data
+            }
+        );
     }
 
-    receive(msg: TokenTransferInternal) { // 0x178d4519
+    receive(msg: TokenTransferInternal){
+        // 0x178d4519
         let ctx: Context = context();
         if (ctx.sender != self.master) {
             let sinit: StateInit = initOf JettonDefaultWallet(msg.from, self.master);
             require(contractAddress(sinit) == ctx.sender, "Invalid sender!");
         }
-
         // Update balance
-        self.balance = self.balance + msg.amount;
-        require(self.balance >= 0, "Invalid balance"); 
-        
+        self.balance = (self.balance + msg.amount);
+        require(self.balance >= 0, "Invalid balance");
         // Get value for gas
-        let msg_value: Int = self.msg_value(ctx.value);  
+        let msg_value: Int = self.msg_value(ctx.value);
         let fwd_fee: Int = ctx.readForwardFee();
-        if (msg.forward_ton_amount > 0) { 
-                msg_value = msg_value - msg.forward_ton_amount - fwd_fee;
-                send(SendParameters{
+        if (msg.forward_ton_amount > 0) {
+            msg_value = ((msg_value - msg.forward_ton_amount) - fwd_fee);
+            send(SendParameters{
                     to: self.owner,
                     value: msg.forward_ton_amount,
                     mode: SendPayGasSeparately,
                     bounce: false,
-                    body: TokenNotification { // 0x7362d09c -- Remind the new Owner
+                    body: TokenNotification{ // 0x7362d09c -- Remind the new Owner
                         query_id: msg.query_id,
                         amount: msg.amount,
                         from: msg.from,
                         forward_payload: msg.forward_payload
                     }.toCell()
-                });
+                }
+            );
         }
-
         // 0xd53276db -- Cashback to the original Sender
-        if (msg.response_destination != null && msg_value > 0) { 
-            send(SendParameters {
-                to: msg.response_destination!!, 
-                value: msg_value,  
-                bounce: false,
-                body: TokenExcesses { query_id: msg.query_id }.toCell(),
-                mode: SendPayGasSeparately
-            });
+        if (msg.response_destination != null && msg_value > 0) {
+            send(SendParameters{
+                    to: msg.response_destination!!,
+                    value: msg_value,
+                    bounce: false,
+                    body: TokenExcesses{query_id: msg.query_id}.toCell(),
+                    mode: SendPayGasSeparately
+                }
+            );
         }
     }
 
-    receive(msg: TokenBurn) {
+    receive(msg: TokenBurn){
         let ctx: Context = context();
-        require(ctx.sender == self.owner, "Invalid sender");  // Check sender
+        require(ctx.sender == self.owner, "Invalid sender"); // Check sender
 
-        self.balance = self.balance - msg.amount; // Update balance
+        self.balance = (self.balance - msg.amount); // Update balance
         require(self.balance >= 0, "Invalid balance");
-
         let fwd_fee: Int = ctx.readForwardFee(); // Gas checks
-        require(ctx.value > fwd_fee + 2 * self.gasConsumption + self.minTonsForStorage, "Invalid value - Burn");
-
+        require(ctx.value > ((fwd_fee + 2 * self.gasConsumption) + self.minTonsForStorage), "Invalid value - Burn");
         // Burn tokens
-        send(SendParameters{  
-            to: self.master,
-            value: 0,
-            mode: SendRemainingValue,
-            bounce: true,
-            body: TokenBurnNotification{
-                query_id: msg.query_id,
-                amount: msg.amount,
-                sender: self.owner,
-                response_destination: msg.response_destination!!
-            }.toCell()
-        });
+        send(SendParameters{
+                to: self.master,
+                value: 0,
+                mode: SendRemainingValue,
+                bounce: true,
+                body: TokenBurnNotification{
+                    query_id: msg.query_id,
+                    amount: msg.amount,
+                    sender: self.owner,
+                    response_destination: msg.response_destination
+                }.toCell()
+            }
+        );
     }
-
 
     fun msg_value(value: Int): Int {
         let msg_value: Int = value;
-        let ton_balance_before_msg: Int = myBalance() - msg_value;
-        let storage_fee: Int = self.minTonsForStorage - min(ton_balance_before_msg, self.minTonsForStorage);
-        msg_value = msg_value - (storage_fee + self.gasConsumption);
+        let ton_balance_before_msg: Int = (myBalance() - msg_value);
+        let storage_fee: Int = (self.minTonsForStorage - min(ton_balance_before_msg, self.minTonsForStorage));
+        msg_value = (msg_value - (storage_fee + self.gasConsumption));
         return msg_value;
     }
 
-    bounced(msg: bounced<TokenTransferInternal>) {
-        self.balance = self.balance + msg.amount;
+    bounced(msg: bounced<TokenTransferInternal>){
+        self.balance = (self.balance + msg.amount);
     }
 
-    bounced(msg: bounced<TokenBurnNotification>) {
-        self.balance = self.balance + msg.amount;
+    bounced(msg: bounced<TokenBurnNotification>){
+        self.balance = (self.balance + msg.amount);
     }
 
     get fun get_wallet_data(): JettonWalletData {
-        return JettonWalletData{
-            balance: self.balance,
-            owner: self.owner,
-            master: self.master,
-            code: (initOf JettonDefaultWallet(self.owner, self.master)).code
-        };
+        return
+            JettonWalletData{
+                balance: self.balance,
+                owner: self.owner,
+                master: self.master,
+                code: initOf JettonDefaultWallet(self.owner, self.master).code
+            };
     }
 }


### PR DESCRIPTION
The existing Token Burn process has an error. 
When using self.requireSenderAsWalletOwner() for permission checking, it incorrectly used the response_destination field instead of the sender field.